### PR TITLE
Improve accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Also you can combine it with Svelte's `{#await ...}`:
 | speed                      | number  | `2`         |                                    |
 | animate                    | boolean | `true`      |                                    |
 | secondaryColorPercentWidth | number  | `100`       | Initial secondaryColor-part offset |
+| ariaLabel                  | ?string | `null`      | Aria Label                         |
 
 Please note that some older browsers (like Internet Explorer 11) do not support SVG animations. They will only show the background color without the animation line. To create skeletons for these browsers, you need to write your own CSS animations.
 

--- a/src/Skeleton.svelte
+++ b/src/Skeleton.svelte
@@ -6,6 +6,7 @@
 	export let speed = 2
 	export let animate = true
 	export let secondaryColorPercentWidth = 100
+	export let ariaLabel = null
 
 	let idClip = getUniqueId()
 	let idGradient = getUniqueId()
@@ -15,7 +16,7 @@
 	}
 </script>
 
-<svg {width} {height} aria-labelledby="loading-aria" preserveAspectRatio="none">
+<svg {width} {height} aria-label={ariaLabel} preserveAspectRatio="none">
 	<rect fill="url(#{idGradient})" clip-path="url(#{idClip})" {width} {height} x="0" y="0" />
 	<defs>
 		<clipPath id={idClip}>


### PR DESCRIPTION
WAVE Report (https://wave.webaim.org/) accessibility tool is marking Svelte Skeleton with error: "Broken ARIA reference". This is one of the highest-level errors that the tool reports.

The report expands on this:

>**What It Means**
An aria-labelledby or aria-describedby reference exists, but the target for the reference does not exist.
**Why It Matters**
ARIA labels and descriptions will not be presented if the element referenced does not exist in the page.
**What To Do**
Ensure the element referenced in the aria-labelledby or aria-describedby attribute value is present within the page and presents a proper label or description.
**The Algorithm... in English**
An element has an aria-labelledby or aria-describedby value that does not match the id attribute value of another element in the page.
**Standards and Guidelines**
[1.3.1 Info and Relationships (Level A)](https://webaim.org/standards/wcag/checklist#sc1.3.1)
[4.1.2 Name, Role, Value (Level A)](https://webaim.org/standards/wcag/checklist#sc4.1.2)

This PR introduces a twofold fix:

- Uses `aria-label` rather than `aria-labelledby` so that an additional element with a matching id to the previously hardcoded "loading-aria" is not required on the page to satisfy.
- Exposes `ariaLabel` as an optional prop, rather than hard-coding it, so that individual developers can opt-in.


